### PR TITLE
Add range-reverse entry

### DIFF
--- a/srfi-196.html
+++ b/srfi-196.html
@@ -416,7 +416,7 @@ the <code><var>ranges</var></code>.</p>
 (range-any &lt; (numeric-range 0 10 2) (numeric-range 5 15)) &rArr; #t
 </code></pre>
 
-<p><code>(range-every</code>&nbsp;<em>pred range</em><code>)</code></p>
+<p><code>(range-every</code>&nbsp;<em>pred range1 range2</em> ...<code>)</code></p>
 <p>Applies <em>pred</em> element-wise to the elements of the
 <em>ranges</em> and returns true if <em>pred</em> returns true on
 every application. Specifically it returns the last value returned by

--- a/srfi-196.html
+++ b/srfi-196.html
@@ -261,6 +261,17 @@ maximum of the average accessing times of the <var>ranges</var>.
   &rArr; (0 1 2 3 4 5)
 </code></pre>
 
+<p><code>(range-reverse</code>&nbsp;<em>range</em><code>)</code></p>
+<p>Returns a range whose elements are the elements of the <em>range</em>
+but in reverse order.  This procedure must run in O(<em>s</em>) time,
+where <em>s</em> is the total accessing time of <em>range</em>.
+The resulting range may be expanded, and should have O(1) average
+accessing time.
+</p>
+<pre class="example"><code>(range-&gt;list (range-reverse (numeric-range 1 4)))
+  &rArr; (3 2 1)
+</code></pre>
+
 <h3 id="predicates">Predicates</h3>
 
 <p><code>(range?</code>&nbsp;<em>obj</em><code>)</code></p>


### PR DESCRIPTION
Cf. https://srfi-email.schemers.org/srfi-196/msg/16983356/

The wording is corrected according to Wolfgang's comment.

The PR also includes another simple editorial error in `range-every` entry.