### PR TITLE
Fix range-any behavior and 'assume' fallback

### DIFF
--- a/srfi-196.html
+++ b/srfi-196.html
@@ -418,7 +418,7 @@ of the <code><var>ranges</var></code>.</p>
 <p><code>(range-any</code>&nbsp;<em>pred range1 range2</em> ...<code>)</code></p>
 <p>Applies <em>pred</em> element-wise to the elements of the
 <em>ranges</em> and returns true if <em>pred</em> returns true on any
-application. Specifically it returns the first value returned by
+application. Specifically it returns the last value returned by
 <em>pred</em>. Otherwise, <code>#f</code> is returned. If more than
 one <em>range</em> is given and not all ranges have the same length,
 <em>range-any</em> terminates when the shortest range is exhausted.

--- a/srfi-196.html
+++ b/srfi-196.html
@@ -418,7 +418,7 @@ of the <code><var>ranges</var></code>.</p>
 <p><code>(range-any</code>&nbsp;<em>pred range1 range2</em> ...<code>)</code></p>
 <p>Applies <em>pred</em> element-wise to the elements of the
 <em>ranges</em> and returns true if <em>pred</em> returns true on any
-application. Specifically it returns the last value returned by
+application. Specifically it returns the first value returned by
 <em>pred</em>. Otherwise, <code>#f</code> is returned. If more than
 one <em>range</em> is given and not all ranges have the same length,
 <em>range-any</em> terminates when the shortest range is exhausted.

--- a/srfi-196.html
+++ b/srfi-196.html
@@ -416,10 +416,9 @@ of the <code><var>ranges</var></code>.</p>
 </code></pre>
 
 <p><code>(range-any</code>&nbsp;<em>pred range1 range2</em> ...<code>)</code></p>
-<p>Applies <em>pred</em> element-wise to the elements of the
-<em>ranges</em> and returns true if <em>pred</em> returns true on any
-application. Specifically it returns the last value returned by
-<em>pred</em>. Otherwise, <code>#f</code> is returned. If more than
+<p>Invokes <em>pred</em> element-wise to the elements of the
+<em>ranges</em> until one call returns a true value, and then returns
+that value. Otherwise, <code>#f</code> is returned. If more than
 one <em>range</em> is given and not all ranges have the same length,
 <em>range-any</em> terminates when the shortest range is exhausted.
 The runtime of this procedure is O(<em>s</em>) where <em>s</em> is the

--- a/srfi/196.sld
+++ b/srfi/196.sld
@@ -23,7 +23,7 @@
      (import (srfi 145)))
     (else
       (begin
-        (define (assume b) #t))))
+        (define (assume . rest) #t))))
 
   (export range numeric-range vector-range string-range range-append
           iota-range range? range=? range-length range-ref range-first


### PR DESCRIPTION
This fixes the sample implementation of `range-any`. The old version ran through the entire range. Somehow, I messed this up and didn't realize it until the 9f7fed errata.

This also fixes the fallback `assume` implementation, which should accept multiple arguments.